### PR TITLE
rename repository name ikawaha to bsoo for go 1.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# for Intellij
+.idea/

--- a/cmd/_dictool/ipa/mkdic.go
+++ b/cmd/_dictool/ipa/mkdic.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/text/encoding/japanese"
 	"golang.org/x/text/transform"
 
-	"github.com/ikawaha/kagome/internal/dic"
+	"github.com/bsoo/kagome/internal/dic"
 )
 
 const (

--- a/internal/dic/index.go
+++ b/internal/dic/index.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"sort"
 
-	"github.com/ikawaha/kagome/internal/da"
+	"github.com/bsoo/kagome/internal/da"
 )
 
 // IndexTable represents a dictionary index.

--- a/internal/dic/sysdic.go
+++ b/internal/dic/sysdic.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"sync"
 
-	"github.com/ikawaha/kagome/internal/dic/data"
+	"github.com/bsoo/kagome/internal/dic/data"
 )
 
 const (

--- a/internal/lattice/lattice.go
+++ b/internal/lattice/lattice.go
@@ -21,7 +21,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/ikawaha/kagome/internal/dic"
+	"github.com/bsoo/kagome/internal/dic"
 )
 
 const (

--- a/internal/lattice/lattice_test.go
+++ b/internal/lattice/lattice_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/ikawaha/kagome/internal/dic"
+	"github.com/bsoo/kagome/internal/dic"
 )
 
 func TestLatticeBuild01(t *testing.T) {

--- a/tokenizer/dic.go
+++ b/tokenizer/dic.go
@@ -14,7 +14,7 @@
 
 package tokenizer
 
-import "github.com/ikawaha/kagome/internal/dic"
+import "github.com/bsoo/kagome/internal/dic"
 
 // Dic represents a dictionary.
 type Dic struct {

--- a/tokenizer/token.go
+++ b/tokenizer/token.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ikawaha/kagome/internal/dic"
-	"github.com/ikawaha/kagome/internal/lattice"
+	"github.com/bsoo/kagome/internal/dic"
+	"github.com/bsoo/kagome/internal/lattice"
 )
 
 // TokenClass represents the token type.

--- a/tokenizer/token_test.go
+++ b/tokenizer/token_test.go
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ikawaha/kagome/internal/dic"
-	"github.com/ikawaha/kagome/internal/lattice"
+	"github.com/bsoo/kagome/internal/dic"
+	"github.com/bsoo/kagome/internal/lattice"
 )
 
 func TestTokenClassString(t *testing.T) {

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -18,8 +18,8 @@ import (
 	"io"
 	"unicode/utf8"
 
-	"github.com/ikawaha/kagome/internal/dic"
-	"github.com/ikawaha/kagome/internal/lattice"
+	"github.com/bsoo/kagome/internal/dic"
+	"github.com/bsoo/kagome/internal/lattice"
 )
 
 // TokenizeMode represents a mode of tokenize.

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ikawaha/kagome/internal/lattice"
+	"github.com/bsoo/kagome/internal/lattice"
 )
 
 const (


### PR DESCRIPTION
これで、go1.5.2で
外部から`internal`以下のディレクトリをインポートしていてビルドできない問題が
解決されているはずです。
